### PR TITLE
 Kafka KRaft 3-broker cluster with full replication 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Middleware (Kafka)
 KAFKA_PORT=9092
-KAFKA_NODE_ID=1
-KAFKA_CONTROLLER_PORT=9093
-KAFKA_HOST=kafka
-KAFKA_NUM_PARTITIONS=1
+KAFKA_HOST=kafka-1
+KAFKA_NUM_PARTITIONS=3
+# Generate once: docker run --rm apache/kafka:4.1.1 kafka-storage random-uuid
+KAFKA_CLUSTER_ID=
 
 # Monitoring
 PROMETHEUS_URL=http://prometheus:9090/api/v1/write

--- a/kafka/create-topics.sh
+++ b/kafka/create-topics.sh
@@ -17,7 +17,7 @@ while IFS=' ' read -r topic retention_ms; do
     --create --if-not-exists \
     --topic "$topic" \
     --partitions 3 \
-    --replication-factor 1 \
+    --replication-factor 3 \
     --config retention.ms="${retention_ms}"
 done < /topics.txt
 

--- a/middleware.yaml
+++ b/middleware.yaml
@@ -1,32 +1,93 @@
 services:
   #---- Middleware
-  kafka:
+  kafka-1:
     image: apache/kafka:4.1.1
-    container_name: kafka
+    container_name: kafka-1
     ports:
-      - "${KAFKA_PORT}:${KAFKA_PORT}"
+      - "${KAFKA_PORT}:9092"
     environment:
-      - KAFKA_NODE_ID=${KAFKA_NODE_ID}
+      - KAFKA_NODE_ID=1
+      - CLUSTER_ID=${KAFKA_CLUSTER_ID}
       - KAFKA_PROCESS_ROLES=broker,controller
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:${KAFKA_PORT},CONTROLLER://0.0.0.0:${KAFKA_CONTROLLER_PORT}
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${KAFKA_HOST}:${KAFKA_PORT}
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-1:9092
       - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
       - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@localhost:${KAFKA_CONTROLLER_PORT}
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
-      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=2
       - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
-      - KAFKA_NUM_PARTITIONS=${KAFKA_NUM_PARTITIONS}
+      - KAFKA_NUM_PARTITIONS=3
       - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost ${KAFKA_PORT} || exit 1"]
+      test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
       interval: 10s
       timeout: 10s
       retries: 20
       start_period: 15s
     volumes:
-      - kafka-data:/var/lib/kafka/data
+      - kafka-1-data:/var/lib/kafka/data
+    networks:
+      - nwdaf-network
+    restart: unless-stopped
+
+  kafka-2:
+    image: apache/kafka:4.1.1
+    container_name: kafka-2
+    environment:
+      - KAFKA_NODE_ID=2
+      - CLUSTER_ID=${KAFKA_CLUSTER_ID}
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-2:9092
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=2
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+      - KAFKA_NUM_PARTITIONS=3
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+      start_period: 15s
+    volumes:
+      - kafka-2-data:/var/lib/kafka/data
+    networks:
+      - nwdaf-network
+    restart: unless-stopped
+
+  kafka-3:
+    image: apache/kafka:4.1.1
+    container_name: kafka-3
+    environment:
+      - KAFKA_NODE_ID=3
+      - CLUSTER_ID=${KAFKA_CLUSTER_ID}
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-3:9092
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=2
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+      - KAFKA_NUM_PARTITIONS=3
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+      start_period: 15s
+    volumes:
+      - kafka-3-data:/var/lib/kafka/data
     networks:
       - nwdaf-network
     restart: unless-stopped
@@ -34,12 +95,18 @@ services:
   kafka-init-topics:
     build: ./kafka
     depends_on:
-      kafka:
+      kafka-1:
+        condition: service_healthy
+      kafka-2:
+        condition: service_healthy
+      kafka-3:
         condition: service_healthy
     environment:
-      - KAFKA_BOOTSTRAP_SERVER=${KAFKA_HOST}:${KAFKA_PORT:-9092}
+      - KAFKA_BOOTSTRAP_SERVER=kafka-1:9092,kafka-2:9092,kafka-3:9092
     networks:
       - nwdaf-network
 
 volumes:
-  kafka-data:
+  kafka-1-data:
+  kafka-2-data:
+  kafka-3-data:

--- a/middleware.yaml
+++ b/middleware.yaml
@@ -1,96 +1,61 @@
+x-kafka-common: &kafka-common
+  image: apache/kafka:4.1.1
+  environment: &kafka-env
+    CLUSTER_ID: ${KAFKA_CLUSTER_ID}
+    KAFKA_PROCESS_ROLES: broker,controller
+    KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+    KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+    KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+    KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
+    KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+    KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+    KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+    KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+    KAFKA_NUM_PARTITIONS: 3
+    KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+  healthcheck:
+    test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
+    interval: 10s
+    timeout: 10s
+    retries: 20
+    start_period: 15s
+  networks:
+    - nwdaf-network
+  restart: unless-stopped
+
 services:
   #---- Middleware
   kafka-1:
-    image: apache/kafka:4.1.1
+    <<: *kafka-common
     container_name: kafka-1
     ports:
       - "${KAFKA_PORT}:9092"
     environment:
-      - KAFKA_NODE_ID=1
-      - CLUSTER_ID=${KAFKA_CLUSTER_ID}
-      - KAFKA_PROCESS_ROLES=broker,controller
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-1:9092
-      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
-      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
-      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=2
-      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
-      - KAFKA_NUM_PARTITIONS=3
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
-    healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
-      start_period: 15s
+      <<: *kafka-env
+      KAFKA_NODE_ID: 1
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:9092
     volumes:
       - kafka-1-data:/var/lib/kafka/data
-    networks:
-      - nwdaf-network
-    restart: unless-stopped
 
   kafka-2:
-    image: apache/kafka:4.1.1
+    <<: *kafka-common
     container_name: kafka-2
     environment:
-      - KAFKA_NODE_ID=2
-      - CLUSTER_ID=${KAFKA_CLUSTER_ID}
-      - KAFKA_PROCESS_ROLES=broker,controller
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-2:9092
-      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
-      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
-      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=2
-      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
-      - KAFKA_NUM_PARTITIONS=3
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
-    healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
-      start_period: 15s
+      <<: *kafka-env
+      KAFKA_NODE_ID: 2
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:9092
     volumes:
       - kafka-2-data:/var/lib/kafka/data
-    networks:
-      - nwdaf-network
-    restart: unless-stopped
 
   kafka-3:
-    image: apache/kafka:4.1.1
+    <<: *kafka-common
     container_name: kafka-3
     environment:
-      - KAFKA_NODE_ID=3
-      - CLUSTER_ID=${KAFKA_CLUSTER_ID}
-      - KAFKA_PROCESS_ROLES=broker,controller
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-3:9092
-      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
-      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
-      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=2
-      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
-      - KAFKA_NUM_PARTITIONS=3
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
-    healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
-      interval: 10s
-      timeout: 10s
-      retries: 20
-      start_period: 15s
+      <<: *kafka-env
+      KAFKA_NODE_ID: 3
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:9092
     volumes:
       - kafka-3-data:/var/lib/kafka/data
-    networks:
-      - nwdaf-network
-    restart: unless-stopped
 
   kafka-init-topics:
     build: ./kafka


### PR DESCRIPTION
## Summary
- Replace single kafka broker with 3-node KRaft cluster 
> as recommended in [apache documentation](https://kafka.apache.org/41/operations/kraft/)

## Scalability gains

- Horizontal scaling: 3 partitions × 3 brokers → parallel consumer throughput
- Fault tolerance: broker failure does not interrupt data pipeline (validated manually)

## Config changes

- `KAFKA_CLUSTER_ID` replaces `KAFKA_NODE_ID` / `KAFKA_CONTROLLER_PORT`
- `KAFKA_HOST=kafka-1` (bootstrap — client auto-discovers kafka-2/3)
- `make env` auto-generates `KAFKA_CLUSTER_ID` on first run

## Validation

Stack started, producers sending data, kafka-1 killed — consumers continued
without interruption. Topics confirmed RF=3, ISR=[1,2,3] on all partitions.

## Considerations
No major changes needs to be done on other components since they just need to connect to first broker and it sends the info about the other brokers.